### PR TITLE
メディアのダウンロードを連続でキャンセルすると、エラー表示が初期化されない問題を修正

### DIFF
--- a/src/components/display/TweetMediaDownloadAlert.vue
+++ b/src/components/display/TweetMediaDownloadAlert.vue
@@ -1,25 +1,21 @@
 <template>
-  <v-sheet v-if="show">
-    <v-expand-transition>
-      <card-alert :type="alertType.warning">
-        <template #content>
-          <p>ダウンロードに失敗したファイルがあります</p>
-          <ul>
-            <li v-for="(text, index) in texts" :key="index">
-              {{ text }}
-            </li>
-          </ul>
-        </template>
-      </card-alert>
-    </v-expand-transition>
-    <v-expand-transition>
-      <expansion-field>
-        <template #button> エラー詳細を表示する </template>
-        <template #content>
-          <v-textarea :value="traces" filled></v-textarea>
-        </template>
-      </expansion-field>
-    </v-expand-transition>
+  <v-sheet>
+    <card-alert :type="alertType.warning">
+      <template #content>
+        <p>ダウンロードに失敗したファイルがあります</p>
+        <ul>
+          <li v-for="(text, index) in texts" :key="index">
+            {{ text }}
+          </li>
+        </ul>
+      </template>
+    </card-alert>
+    <expansion-field>
+      <template #button> エラー詳細を表示する </template>
+      <template #content>
+        <v-textarea :value="traces" filled></v-textarea>
+      </template>
+    </expansion-field>
   </v-sheet>
 </template>
 

--- a/src/components/display/TweetMediaDownloadAlert.vue
+++ b/src/components/display/TweetMediaDownloadAlert.vue
@@ -43,14 +43,6 @@ export default Vue.extend({
   },
   computed: {
     /**
-     * アラートの表示・非表示フラグ
-     */
-    show: {
-      get(): boolean {
-        return this.errors.length > 0
-      },
-    },
-    /**
      * アラートの文言
      * propsで渡されたエラー情報をエラーメッセージごとにユニーク化する
      */

--- a/src/modules/mediaZipGenerator.ts
+++ b/src/modules/mediaZipGenerator.ts
@@ -3,6 +3,7 @@
  */
 
 import JSZip from 'jszip'
+import { MediaDownloadError } from '~/modules/customError'
 import { Content } from '~/modules/mediaDownloader'
 
 /**
@@ -26,7 +27,7 @@ class MediaZipGenerator {
   }
 
   /**
-   * メディアのダウンロード処理を行うクラス
+   * ZIPファイルに格納するメディアファイルの一覧
    */
   private readonly _contents: Content[]
 
@@ -40,7 +41,7 @@ class MediaZipGenerator {
   }
 
   /**
-   * メディアをダウンロードして、ZIPファイルのURLを生成する
+   * ZIPファイルのURLを生成する
    */
   async generate() {
     // ZIPファイルの作成
@@ -53,18 +54,17 @@ class MediaZipGenerator {
    * @param contents コンテンツ情報
    * @param name ZIPファイル名
    * @returns ZIPファイルのデータ
-   * @throws {@link Error} ZIPファイルの作成に失敗した場合
+   * @throws {@link MediaDownloadError} ZIPファイルの作成に失敗した場合
    */
   private async _generateZipBlob(contents: Content[], name: string) {
     const zip = new JSZip()
     const folder = zip.folder(name)
 
     if (folder === null) {
-      throw new TypeError('フォルダの作成に失敗しました')
+      throw new MediaDownloadError('ZIPファイルの作成に失敗しました')
     }
 
     for (const content of contents) {
-      // folder.file(content.name, content.blob)
       folder.file(content.name, content.blob)
     }
 

--- a/src/test/components/display/TweetMediaDownloadAlert.spec.ts
+++ b/src/test/components/display/TweetMediaDownloadAlert.spec.ts
@@ -9,10 +9,12 @@ describe('メディアダウンロード用アラート表示', () => {
   }
   type Props = typeof props
 
-  test('エラー情報が追加されると、アラートが表示される', async () => {
-    // v-ifによる表示の変化を確認したいため、スタブ化を行わないmount()を使う
+  test('エラー情報が追加されると、アラートに反映される', async () => {
     const mountedWrapper = mount(TweetMediaDownloadAlert, { propsData: props })
-    expect(mountedWrapper.find('div.v-alert').exists()).toBe(false) // v-ifで制御しているため、要素自体が描画されないことを検証する
+
+    // 初期表示の検証
+    const alert = mountedWrapper.find('div.v-alert')
+    expect(alert.text()).toContain('')
 
     // エラーの追加
     const propsData: Props = JSON.parse(JSON.stringify(props))
@@ -22,20 +24,20 @@ describe('メディアダウンロード用アラート表示', () => {
     await mountedWrapper.setProps(propsData)
 
     // 値の検証
-    const alert = mountedWrapper.find('div.v-alert')
-    expect(alert.text()).toContain(
+    const addedAlert = mountedWrapper.find('div.v-alert')
+    expect(addedAlert.text()).toContain(
       'メディアのダウンロード中にエラーが発生しました',
     )
-    expect(alert.isVisible()).toBe(true)
   })
 
-  test('エラー情報が追加されると、エラー詳細が表示される', async () => {
-    // v-ifによる表示の変化を確認したいため、スタブ化を行わないmount()を使う
+  test('エラー情報が追加されると、エラー詳細に反映される', async () => {
     const mountedWrapper = mount(TweetMediaDownloadAlert, { propsData: props })
-    expect(mountedWrapper.find('div.expansion-field').exists()).toBe(false) // v-ifで制御しているため、要素自体が描画されないことを検証する
 
     // エラーの追加
     const propsData: Props = JSON.parse(JSON.stringify(props))
+    propsData.errors.push(
+      new MediaDownloadError('メディアのダウンロード中にエラーが発生しました'),
+    )
     propsData.errors.push(
       new MediaDownloadError({
         message: 'メディアが見つかりませんでした',
@@ -50,10 +52,6 @@ describe('メディアダウンロード用アラート表示', () => {
     )
     await mountedWrapper.setProps(propsData)
 
-    // 表示枠の検証
-    const field = mountedWrapper.find('div.expansion-field')
-    expect(field.isVisible()).toBe(true)
-
     // 値の検証
     // 検証用の値を用意する
     const filteredData = propsData.errors.filter((error) => {
@@ -65,6 +63,7 @@ describe('メディアダウンロード用アラート表示', () => {
     const traces = mappedData.join('\n')
 
     // エラー詳細の値を検証する
+    const field = mountedWrapper.find('div.expansion-field')
     await field.find('.button').trigger('click') // 表示ボタンを押して、内容をHTML内に展開する
     const textarea = field.find('textarea')
     assertIsTextArea(textarea.element) // テキストエリアの値を取得するために、専用の型であることを保証する（valueプロパティが存在する型へ変換する）

--- a/src/test/components/display/TweetMediaDownloadButton.spec.ts
+++ b/src/test/components/display/TweetMediaDownloadButton.spec.ts
@@ -71,39 +71,34 @@ describe('メディアダウンロードボタン', () => {
     test('ダイアログにアラート表示用スペースが存在する', async () => {
       await wrapper.setData({ dialog: true })
 
-      // 初期状態（表示なし）の検証
       const dialog = wrapper.find('v-dialog-stub')
       const alert = dialog.find('tweet-media-download-alert-stub')
-      expect(alert.exists()).toBe(false)
+      expect(alert.attributes('errors')).toBe('')
 
       // エラー情報の追加
       await wrapper.setData({
-        downloader: {
-          instance: new MediaDownloader([]),
-          errors: [
-            new MediaDownloadError('test'),
-            new MediaDownloadError('test2'),
-          ],
-        },
+        errors: [
+          new MediaDownloadError('test'),
+          new MediaDownloadError('test2'),
+        ],
       })
       const addedAlert = dialog.find('tweet-media-download-alert-stub')
       expect(addedAlert.attributes('errors')).toBe(
         'MediaDownloadError: test,MediaDownloadError: test2',
       )
-      expect(addedAlert.exists()).toBe(true)
     })
 
-    test('ダイアログにキャンセルボタン・ダウンロードボタンが表示される', async () => {
+    test('ダイアログにキャンセルボタン（閉じるボタン）・ダウンロードボタンが表示される', async () => {
       await wrapper.setData({ dialog: true })
       const dialog = wrapper.find('v-dialog-stub')
 
       // 初期状態の検証
       // キャンセルボタン
-      const cancelButton = dialog.find('v-btn-stub.cancel')
+      const cancelButton = dialog.find('v-card-actions-stub v-btn-stub')
       expect(cancelButton.text()).toBe('キャンセル')
 
       // ダウンロードボタン
-      const downloadButton = dialog.find('v-btn-stub.download')
+      const downloadButton = dialog.find('v-card-text-stub v-btn-stub')
       expect(downloadButton.text()).toBe('ダウンロード')
       expect(downloadButton.attributes('href')).toBe('')
       expect(downloadButton.attributes('download')).toBe('medias.zip')
@@ -127,6 +122,10 @@ describe('メディアダウンロードボタン', () => {
       expect(downloadButton.attributes('href')).toBe(file.objectUrl)
       expect(downloadButton.attributes('download')).toBe(`${file.name}.zip`)
       expect(downloadButton.attributes('loaoding')).toBeUndefined() // falseの場合は未定義となる
+
+      // 閉じるボタン（キャンセルボタンと入れ替わりで表示される）
+      const closeButton = dialog.find('v-card-actions-stub v-btn-stub')
+      expect(closeButton.text()).toBe('閉じる')
     })
   })
 
@@ -143,7 +142,7 @@ describe('メディアダウンロードボタン', () => {
       await button.trigger('click')
 
       expect(mountedWrapper.find('div.v-dialog--active').exists()).toBe(true)
-      expect(mountedWrapper.vm.$data.downloader.instance.download).toBeCalled()
+      expect(mountedWrapper.vm.$data.downloader.download).toBeCalled()
     })
 
     test('キャンセルボタンを押すと、キャンセル処理が行われる', async () => {


### PR DESCRIPTION
## 変更の概要
<!-- プルリクエストの経緯や理由を記載する -->
<!-- Issueが立っている場合は、"関連Issue"の記載のみで可 -->

- メディアのダウンロードを連続でキャンセルしても、毎回エラー表示が初期化されるように修正
  - 初期化の設定が不十分で、過去のエラーが初期化されずに残ってしまっていた
- ダウンロードボタンコンポーネントのデータの持ち方をよりシンプルな形に改善
- 「キャンセル」ボタンを押した際の動き・デザインを微修正

### 関連Issue
<!-- Issueが立っている場合は、番号を記載して紐付けを行う -->
<!-- プルリクエストのマージ時に、該当Issueは自動的にクローズされる -->

- close: #

## 期待される機能
<!-- 機能要件を明確にする意図がある。外部から見た振る舞いの記載のみで（実装の中身まで踏み込まなくて）OK -->
<!-- 今回のプルリクエストでやらないことがあれば、合わせて記載する（対応計画のIssueを立てて、その旨を記載しているとベスト） -->

- [x] メディアのダウンロードを連続でキャンセルした際、ダイアログ上に前回のエラー表示が残っていない
- [x] キャンセルボタンを押した場合に、キャンセル結果がダイアログ上に表示される
- [x] キャンセルボタンを押した場合に、キャンセルボタンが閉じるボタンに変化する  

## 実装内容
<!-- 実装の方針等、大雑把な内容でOK（詳細を確認する際はコードを読むため） -->
<!-- 特に見て欲しい箇所・期待するレビューの観点等があれば、合わせて記載する -->

### ダウンロードボタンのコンポーネント

- データの持ち方をよりシンプルな形に改善
  - エラー情報の持ち方が実装の想定と合っておらず、それにより今回の問題が発生していた
    - シンプルな形に変更したことで、同様の問題は起きづらくなったかも…？
  - 合わせて、ダウンロード用クラスの格納先もシンプルなものに変更
- ZIPファイル生成に関するエラーハンドリングを強化
  - 後述のZIPファイルの生成処理を修正した影響


#### キャンセルボタンを押した際の挙動を変更

- 以下の思想で変更しています
  - 「とにかく急いで閉じたい！」という場合はダイアログの外側をクリック
  - キャンセルした場合に、キャンセル結果をフィードバック（エラーの表示）したい
    - しかし、「キャンセル=閉じる」と考えるユーザーもいると思うので、関連性が分かりやすいようにキャンセルボタンの近くに（または同じ役割で）閉じるボタンを用意する

##### 旧

1. ボタンを押したらダイアログが閉じる

##### 新

1. ボタンを押すとキャンセル処理が行われる
2. キャンセルに関するエラーがダイアログに表示される
3. 「キャンセル」ボタンが「閉じる」ボタンに変化する
4. 「閉じる」ボタンを押すと、ダイアログが閉じる

#### ZIPファイルの生成処理を微修正

- ZIPファイルが展開できない場合に発生するエラーを`MediaDownloadError`に変更
  - 投げっぱなしではなく、捉えてフィードバックすべき例外と認識を改めたため
  - `TypeError`のままだとコンポーネント上で扱いづらかった
    - 前の処理（ダウンロード処理）で発生するエラーは`MediaDownloadError`オンリーなため、コンポーネント上で扱いやすくすることも含めてなるべく統一したかった 

### ダウンロード処理のアラートを表示するコンポーネント

- 表示に関する制御構文を削除
  - より上位のコンポーネントで制御するべきだと思ったので

### テストの修正

コンポーネントの変更に合わせて修正

## テストの実施
<!-- 手動でテストを行った場合は、テストの手順を記載する -->

<!-- 以下のいずれかに該当する場合はチェックを入れる -->
- [x] テストを実施した
  - テストコードを記載・実行している
  - 手動でテストを行った
  - 軽微な修正のため必要なし

## 頑張った点・工夫した点
<!-- 褒めてもらいたい箇所 -->

修正箇所を見てみると、不要なコメントアウトを削除していなかったり、いろいろ迂闊な感じだった…気をつけよう

## 伝達事項
<!-- 今後の開発に役立つ（または注意すべき）情報 -->
